### PR TITLE
chore: enforce utf-8 + consistent line endings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,21 +1,9 @@
-root = true
+﻿root = true
 
 [*]
 charset = utf-8
 end_of_line = lf
 insert_final_newline = true
-trim_trailing_whitespace = true
-indent_style = space
-indent_size = 4
 
-[*.{yml,yaml}]
-indent_size = 2
-
-[*.{json,js,ts}]
-indent_size = 2
-
-[*.md]
-trim_trailing_whitespace = false
-
-[Makefile]
-indent_style = tab
+[*.ps1]
+end_of_line = crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+﻿* text=auto
+*.md text working-tree-encoding=UTF-8


### PR DESCRIPTION
@codex run a code review on this PR.
Focus: confirm .gitattributes/.editorconfig correctly enforce UTF-8 and safe EOLs across Windows/macOS/Linux.

